### PR TITLE
Implement support to create releases in mirror repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![MIT license][license-image]][license-url]
 [![Support][support-image]][support-url]
 
-This repository contains a set of scripts to serve as a mirroring service for Github repositories.
+This repository contains a set of scripts to serve as a mirroring service for GitHub repositories.
 
 ## Operating System
 
@@ -21,6 +21,7 @@ The service has been developed and tested under Ubuntu 14.04 OS.
 
 * [PyYAML](http://pyyaml.org/)
 * [PyGithub](https://pypi.python.org/pypi/PyGithub)
+* [Requests](https://pypi.python.org/pypi/requests/)
 
 ## Installation and configuration guide
 
@@ -57,10 +58,16 @@ Now you are able to install the Python dependencies:
 	sudo pip install pyyaml
 	```
 
-* PyGithub, used to access the Github API via Python code:
+* PyGithub, used to access the GitHub API via Python code:
 
 	```
 	sudo pip install pygithub
+	```
+
+* Requests, used to access the GitHub API via Python code where PyGithub does not support the GitHub API:
+
+	```
+	sudo pip install requests
 	```
 
 ### Deploying the code
@@ -85,17 +92,17 @@ The following changes are needed for the service to work as expected:
 
 * The **workspace** key inside the **conf.yaml** file must be set to the desired folder to clone repositories.
 
-* The user **<username>** must be able to `git clone` and `git push` to the remote repository. This means that the user must have correctly set up its SSH credentials to access Github.
+* The user **<username>** must be able to `git clone` and `git push` to the remote repository. This means that the user must have correctly set up its SSH credentials to access GitHub.
 
 #### Web service
 
 All the contents of the **web** directory must be inside **/var/www/html/mirror**. This way the access URLs will be of the form `http://<server-ip>/mirror/<action-entry-point>`.
 
-Inside **index.php** the followint variables should be updated accordingly:
+Inside **index.php** the following variables should be updated accordingly:
 
 * **update_script**: Path to the script **update-mirror.py**.
 * **deny_script**: Path to the script **deny-pull-requests.py**.
-* **github_token_file**: Path to the textfile containing the Github API token
+* **github_token_file**: Path to the textfile containing the GitHub API token
 
 ##### Apache configuration
 
@@ -149,7 +156,7 @@ setup-mirror.py <github_source_clone_url> <github_mirror_remote_url> <path_to_to
 
 **Example:**
 ```
-setup-mirror.py https://github.com/telefonicaid/fiware-orion.git git@github.com:Fiware/context.Orion.git utils/github-token.txt
+setup-mirror.py https://github.com/telefonicaid/fiware-orion.git git@github.com:Fiware/context.Orion.git utils/github-token
 ```
 
 ## Troubleshooting

--- a/script/README.md
+++ b/script/README.md
@@ -4,7 +4,7 @@
 * The **setup-mirror.py** script is provided to allow the initialization of a mirror repository without using the web service. It will also populate **conf.yaml** with the appropiate values and structure.
 * The **update-def-mirros.py** script allows the user to create or update the definition, name and the pull request bot URL in a list of repositories.
 * The **deny-pull-requests.py** script acts as the backend for the bot that automatically closes pull requests in mirrored repositories.
-* The **recreate-releases.py** script allows the user to delete and create every release in a list of repositories.
+* The **recreate-releases.py** script allows the user to delete and create all the releases in a list of repositories.
 
 
 * The **utils** directory contains different utilities for managing the local repositories and the github account where to hold the mirrors.

--- a/script/README.md
+++ b/script/README.md
@@ -4,5 +4,7 @@
 * The **setup-mirror.py** script is provided to allow the initialization of a mirror repository without using the web service. It will also populate **conf.yaml** with the appropiate values and structure.
 * The **update-def-mirros.py** script allows the user to create or update the definition, name and the pull request bot URL in a list of repositories.
 * The **deny-pull-requests.py** script acts as the backend for the bot that automatically closes pull requests in mirrored repositories.
+* The **recreate-releases.py** script allows the user to delete and create every release in a list of repositories.
+
 
 * The **utils** directory contains different utilities for managing the local repositories and the github account where to hold the mirrors.

--- a/script/conf.yaml.example
+++ b/script/conf.yaml.example
@@ -1,4 +1,5 @@
 workspace: "/home/fiwareulpgc/mirrors/repos"
+pr_hook_url: "http://webhook.fiware.org/mirror/deny-pull-request"
 source_repo_urls:
   'https://github.com/telefonicaid/fiware-orion.git':
     mirror_remote_url: "git@github.com:Fiware/context.Orion.git"

--- a/script/deny-pull-requests.py
+++ b/script/deny-pull-requests.py
@@ -12,61 +12,65 @@ sys.path.append(os.path.dirname(__file__))
 from utils.githubmirrorutils import GithubMirrorUtils
 from utils.utils import *
 
+
 def deny_pull_requests(payload_or_payload_file, token_file):
-	
-	try:
-		body = json.loads(payload_or_payload_file)
-	except ValueError as error:
-		with open(payload_or_payload_file, "r") as f:
-			body = json.load(f)
 
-	directory = os.path.dirname(os.path.abspath(__file__))
-	with open(directory+"/conf.yaml", "r") as f:
-		config = yaml.load(f)
-		config["workspace"] = os.path.expanduser(config["workspace"])
+    try:
+        body = json.loads(payload_or_payload_file)
+    except ValueError as error:
+        with open(payload_or_payload_file, "r") as f:
+            body = json.load(f)
 
-	mirror_remote_url_from_body = body['repository']['ssh_url']
-	mirror_user_repo_name = None
+    directory = os.path.dirname(os.path.abspath(__file__))
+    with open(directory+"/conf.yaml", "r") as f:
+        config = yaml.load(f)
+        config["workspace"] = os.path.expanduser(config["workspace"])
 
-	for repo_clone_url in config['source_repo_urls']:
-		mirror_remote_url = config['source_repo_urls'][repo_clone_url]["mirror_remote_url"]
+    mirror_remote_url_from_body = body['repository']['ssh_url']
+    mirror_user_repo_name = None
 
-		if mirror_remote_url == mirror_remote_url_from_body:
-			src_url = repo_clone_url
-			mirror_user_repo_name = get_user_repo_from_github_url(mirror_remote_url)
-		
-			print mirror_user_repo_name
-			break
+    for repo_clone_url in config['source_repo_urls']:
+        mirror_remote_url =\
+            config['source_repo_urls'][repo_clone_url]["mirror_remote_url"]
 
-	if mirror_user_repo_name is None:
-		print "Entry {} not found in configuration file.".format(mirror_remote_url_from_body)
-		return
+        if mirror_remote_url == mirror_remote_url_from_body:
+            src_url = repo_clone_url
+            mirror_user_repo_name =\
+                get_user_repo_from_github_url(mirror_remote_url)
 
-	g = GithubMirrorUtils(tokenfile=token_file)
+            print mirror_user_repo_name
+            break
 
-	org_name = mirror_user_repo_name['user']
-	repo_name = mirror_user_repo_name['repo']
-	pull_request_number = body['pull_request']['number']
+    if mirror_user_repo_name is None:
+        print ("Entry {} not found in configuration "
+               "file.").format(mirror_remote_url_from_body)
+        return
 
-	print "org_name:", org_name
-	print "repo_name:", repo_name
-	print "pull_request_number:", pull_request_number
-	print "src_url:", src_url
+    g = GithubMirrorUtils(tokenfile=token_file)
 
-	g.close_pull_request(org_name, repo_name, pull_request_number, src_url)
+    org_name = mirror_user_repo_name['user']
+    repo_name = mirror_user_repo_name['repo']
+    pull_request_number = body['pull_request']['number']
+
+    print "org_name:", org_name
+    print "repo_name:", repo_name
+    print "pull_request_number:", pull_request_number
+    print "src_url:", src_url
+
+    g.close_pull_request(org_name, repo_name, pull_request_number, src_url)
 
 
 if __name__ == "__main__":
 
-	if len(sys.argv) < 3: 
-		print "Less than two arguments were passed."
-		sys.exit(-1)
+    if len(sys.argv) < 3:
+        print "Less than two arguments were passed."
+        sys.exit(-1)
 
-	elif len(sys.argv) > 3: 
-		print "Only 2 arguments are accepted."
-		sys.exit(-2)
+    elif len(sys.argv) > 3:
+        print "Only 2 arguments are accepted."
+        sys.exit(-2)
 
-	payload_or_payload_file = sys.argv[1]
-	token_file = sys.argv[2]
+    payload_or_payload_file = sys.argv[1]
+    token_file = sys.argv[2]
 
-	deny_pull_requests(payload_or_payload_file, token_file)
+    deny_pull_requests(payload_or_payload_file, token_file)

--- a/script/deny-pull-requests.py
+++ b/script/deny-pull-requests.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env  python
 
+"""Script to automatically close pull requests in mirrored repositories.
+
+This module is invoked from PHP when PR events arrive from mirrorred 
+repositories.
+
+"""
+
 import json
 import os
 import shutil

--- a/script/deny-pull-requests.py
+++ b/script/deny-pull-requests.py
@@ -62,13 +62,9 @@ def deny_pull_requests(payload_or_payload_file, token_file):
 
 if __name__ == "__main__":
 
-    if len(sys.argv) < 3:
-        print "Less than two arguments were passed."
-        sys.exit(-1)
-
-    elif len(sys.argv) > 3:
+    if len(sys.argv) != 3:
         print "Only 2 arguments are accepted."
-        sys.exit(-2)
+        sys.exit(-1)
 
     payload_or_payload_file = sys.argv[1]
     token_file = sys.argv[2]

--- a/script/recreate-releases.py
+++ b/script/recreate-releases.py
@@ -12,30 +12,28 @@ from utils.utils import *
 from utils.githubmirrorutils import GithubMirrorUtils
 
 
-def update_def_mirrors(token_file):
+def recreate_releases(token_file):
 
     directory = os.path.dirname(os.path.abspath(__file__))
 
     with open(directory+"/conf.yaml", "r") as f:
         config = yaml.load(f)
         config["workspace"] = os.path.expanduser(config["workspace"])
-        pr_hook_url = config["pr_hook_url"]
 
     for repo_clone_url in config['source_repo_urls']:
         mirror_remote_url =\
             config['source_repo_urls'][repo_clone_url]["mirror_remote_url"]
         mirror_user_repo_name =\
             get_user_repo_from_github_url(mirror_remote_url)
-
-        print mirror_user_repo_name
+        clone_user_repo_name = get_user_repo_from_github_url(repo_clone_url)
 
         g = GithubMirrorUtils(tokenfile=token_file)
-        g.create_update_mirror_repo(mirror_user_repo_name['user'],
-                                    mirror_user_repo_name['repo'],
-                                    repo_clone_url,
-                                    pr_hook_url)
+        g.recreate_releases(clone_user_repo_name['user'],
+                            clone_user_repo_name['repo'],
+                            mirror_user_repo_name['user'],
+                            mirror_user_repo_name['repo'])
 
 
 if __name__ == "__main__":
 
-    update_def_mirrors(sys.argv[1])
+    recreate_releases(sys.argv[1])

--- a/script/recreate-releases.py
+++ b/script/recreate-releases.py
@@ -1,5 +1,11 @@
 #! /usr/bin/env  python
 
+"""Script to delete and create all mirrored repositories releases.
+
+The list of mirrored repositories to treat is read from the configuration file.
+
+"""
+
 import os
 import shutil
 from subprocess import call

--- a/script/recreate-releases.py
+++ b/script/recreate-releases.py
@@ -36,4 +36,8 @@ def recreate_releases(token_file):
 
 if __name__ == "__main__":
 
+    if len(sys.argv) != 2:
+        print "Only 1 argument is accepted."
+        sys.exit(-1)
+
     recreate_releases(sys.argv[1])

--- a/script/setup-mirror.py
+++ b/script/setup-mirror.py
@@ -64,13 +64,9 @@ def setup_mirror(repo_clone_url, mirror_remote_url, token_file, pr_hook_url):
 
 if __name__ == "__main__":
 
-    if len(sys.argv) < 4:
-        print "Three arguments arguments are needed."
-        sys.exit(-1)
-
-    elif len(sys.argv) > 4:
+    if len(sys.argv) != 4:
         print "Only 3 arguments are accepted."
-        sys.exit(-2)
+        sys.exit(-1)
 
     repo_clone_url = sys.argv[1]
     mirror_remote_url = sys.argv[2]

--- a/script/setup-mirror.py
+++ b/script/setup-mirror.py
@@ -11,57 +11,69 @@ sys.path.append(os.path.dirname(__file__))
 from utils.utils import *
 from utils.githubmirrorutils import GithubMirrorUtils
 
-pr_hook_url = 'http://130.206.84.20/mirror/deny-pull-request'
 
 def setup_mirror(repo_clone_url, mirror_remote_url, token_file, pr_hook_url):
 
-	directory = os.path.dirname(os.path.abspath(__file__))
+    directory = os.path.dirname(os.path.abspath(__file__))
 
-	with open(directory+"/conf.yaml", "r") as f:
-		config = yaml.load(f)
-		config["workspace"] = os.path.expanduser(config["workspace"])
-		
-	mirror_user_repo_name = get_user_repo_from_github_url(mirror_remote_url)
-	repository_folder = "{}/{}_{}".format(config["workspace"], mirror_user_repo_name['user'], mirror_user_repo_name['repo'])
+    with open(directory+"/conf.yaml", "r") as f:
+        config = yaml.load(f)
+        config["workspace"] = os.path.expanduser(config["workspace"])
+        pr_hook_url = config["pr_hook_url"]
 
-	if not os.path.exists(repository_folder):
+    mirror_user_repo_name = get_user_repo_from_github_url(mirror_remote_url)
+    clone_user_repo_name = get_user_repo_from_github_url(repo_clone_url)
+    repository_folder = "{}/{}_{}".format(config["workspace"],
+                                          mirror_user_repo_name['user'],
+                                          mirror_user_repo_name['repo'])
 
-		g = GithubMirrorUtils(token_file)
+    g = GithubMirrorUtils(token_file)
 
-		g.create_update_mirror_repo(mirror_user_repo_name['user'], mirror_user_repo_name['repo'], repo_clone_url, pr_hook_url)
+    if not os.path.exists(repository_folder):
 
-		os.makedirs(repository_folder)
+        g.create_update_mirror_repo(mirror_user_repo_name['user'],
+                                    mirror_user_repo_name['repo'],
+                                    repo_clone_url,
+                                    pr_hook_url)
 
-		if not "source_repo_urls" in config:
-			config["source_repo_urls"] = {}
+        os.makedirs(repository_folder)
 
-		config["source_repo_urls"][repo_clone_url] = {"mirror_remote_url": mirror_remote_url}
+        if not ("source_repo_urls" in config):
+            config["source_repo_urls"] = {}
 
-		with open(directory+"/conf.yaml", "w") as f:
-			yaml.dump(config, f, default_flow_style=False)
+        config["source_repo_urls"][repo_clone_url] = {"mirror_remote_url":
+                                                      mirror_remote_url}
 
+        with open(directory+"/conf.yaml", "w") as f:
+            yaml.dump(config, f, default_flow_style=False)
 
-	call(["git", "clone", "--mirror", repo_clone_url, repository_folder])
+    call(["git", "clone", "--mirror", repo_clone_url, repository_folder])
 
-	with cd(repository_folder):
-		call(["git", "remote", "set-url", "--push", "origin", mirror_remote_url])
-		
-		call(["git", "fetch", "-p", "origin"])
-		call(["git", "push", "--mirror"])
+    with cd(repository_folder):
+        call(["git", "remote", "set-url", "--push", "origin",
+              mirror_remote_url])
+
+        call(["git", "fetch", "-p", "origin"])
+        call(["git", "push", "--mirror"])
+
+    g.recreate_releases(clone_user_repo_name['user'],
+                        clone_user_repo_name['repo'],
+                        mirror_user_repo_name['user'],
+                        mirror_user_repo_name['repo'])
 
 
 if __name__ == "__main__":
 
-	if len(sys.argv) < 4: 
-		print "Three arguments arguments are needed."
-		sys.exit(-1)
+    if len(sys.argv) < 4:
+        print "Three arguments arguments are needed."
+        sys.exit(-1)
 
-	elif len(sys.argv) > 4: 
-		print "Only 3 arguments are accepted."
-		sys.exit(-2)
+    elif len(sys.argv) > 4:
+        print "Only 3 arguments are accepted."
+        sys.exit(-2)
 
-	repo_clone_url = sys.argv[1]
-	mirror_remote_url = sys.argv[2]
-	token_file = sys.argv[3]
+    repo_clone_url = sys.argv[1]
+    mirror_remote_url = sys.argv[2]
+    token_file = sys.argv[3]
 
-	setup_mirror(repo_clone_url, mirror_remote_url, token_file, pr_hook_url)
+    setup_mirror(repo_clone_url, mirror_remote_url, token_file, pr_hook_url)

--- a/script/setup-mirror.py
+++ b/script/setup-mirror.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env  python
 
+"""Script to register a new repository to be mirrored and create the mirror.
+
+This script will add the correct new entries for the source and mirror
+repositories inside the configuration file.
+
+"""
+
 import os
 import shutil
 from subprocess import call

--- a/script/update-def-mirrors.py
+++ b/script/update-def-mirrors.py
@@ -38,4 +38,8 @@ def update_def_mirrors(token_file):
 
 if __name__ == "__main__":
 
+    if len(sys.argv) != 2:
+        print "Only 1 argument is accepted."
+        sys.exit(-1)
+
     update_def_mirrors(sys.argv[1])

--- a/script/update-def-mirrors.py
+++ b/script/update-def-mirrors.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env  python
 
+"""Script to update the mirror description and deny PR hook configuration.
+
+The operation is executed for all mirror repositories defined in the
+configuration file.
+
+"""
+
 import os
 import shutil
 from subprocess import call

--- a/script/update-mirror.py
+++ b/script/update-mirror.py
@@ -59,13 +59,9 @@ def update_mirror(event, payload_or_payload_file, token_file):
 
 if __name__ == "__main__":
 
-    if len(sys.argv) < 4:
-        print "Less than 3 arguments were passed."
-        sys.exit(-1)
-
-    elif len(sys.argv) > 4:
+    if len(sys.argv) != 4:
         print "Only 3 arguments are accepted."
-        sys.exit(-2)
+        sys.exit(-1)
 
     event = sys.argv[1]
     payload_or_payload_file = sys.argv[2]

--- a/script/update-mirror.py
+++ b/script/update-mirror.py
@@ -9,49 +9,66 @@ import sys
 import yaml
 
 sys.path.append(os.path.dirname(__file__))
+from utils.githubmirrorutils import GithubMirrorUtils
 from utils.utils import *
 
 
-def update_mirror(payload_or_payload_file):
-	try:
-		body = json.loads(payload_or_payload_file)
-	except ValueError as error:
-		with open(payload_or_payload_file, "r") as f:
-			body = json.load(f)
+def update_mirror(event, payload_or_payload_file, token_file):
+    try:
+        body = json.loads(payload_or_payload_file)
+    except ValueError as error:
+        with open(payload_or_payload_file, "r") as f:
+            body = json.load(f)
 
-	directory = os.path.dirname(os.path.abspath(__file__))
-	with open(directory+"/conf.yaml", "r") as f:
-		config = yaml.load(f)
-		config["workspace"] = os.path.expanduser(config["workspace"])
+    directory = os.path.dirname(os.path.abspath(__file__))
+    with open(directory+"/conf.yaml", "r") as f:
+        config = yaml.load(f)
+        config["workspace"] = os.path.expanduser(config["workspace"])
 
-	repo_clone_url = body['repository']['clone_url']
-	mirror_remote_url = config["source_repo_urls"][repo_clone_url]["mirror_remote_url"]
+    repo_clone_url = body['repository']['clone_url']
+    mirror_remote_url =\
+        config["source_repo_urls"][repo_clone_url]["mirror_remote_url"]
 
-	user_repo_name = get_user_repo_from_github_url(mirror_remote_url)
-	repository_folder = "{}/{}_{}".format(config["workspace"], user_repo_name['user'], user_repo_name['repo'])
+    user_repo_name = get_user_repo_from_github_url(mirror_remote_url)
+    repository_folder = "{}/{}_{}".format(config["workspace"],
+                                          user_repo_name['user'],
+                                          user_repo_name['repo'])
 
-	if not os.path.exists(repository_folder):
-		os.makedirs(repository_folder)
-		
-		call(["git", "clone", "--mirror", repo_clone_url, repository_folder])
+    if not os.path.exists(repository_folder):
+        os.makedirs(repository_folder)
 
-	with cd(repository_folder):
-		call(["git", "remote", "set-url", "--push", "origin", mirror_remote_url])
-		
-		call(["git", "fetch", "-p", "origin"])
-		call(["git", "push", "--mirror"])
+        call(["git", "clone", "--mirror", repo_clone_url, repository_folder])
+
+    with cd(repository_folder):
+        call(["git", "remote", "set-url", "--push", "origin",
+              mirror_remote_url])
+
+        call(["git", "fetch", "-p", "origin"])
+        call(["git", "push", "--mirror"])
+
+    if event == "release":
+
+        g = GithubMirrorUtils(tokenfile=token_file)
+
+        g.create_release(user_repo_name['user'], user_repo_name['repo'],
+                         body["release"]["tag_name"], body["release"]["name"],
+                         body["release"]["body"], body["release"]["draft"],
+                         body["release"]["prerelease"],
+                         body["release"]["assets"])
 
 
 if __name__ == "__main__":
 
-	if len(sys.argv) < 2: 
-		print "No arguments were passed."
-		sys.exit(-1)
+    if len(sys.argv) < 4:
+        print "Less than 3 arguments were passed."
+        sys.exit(-1)
 
-	elif len(sys.argv) > 2: 
-		print "Only one argument is accepted."
-		sys.exit(-2)
+    elif len(sys.argv) > 4:
+        print "Only 3 arguments are accepted."
+        sys.exit(-2)
 
-	payload_or_payload_file = sys.argv[1]
+    event = sys.argv[1]
+    payload_or_payload_file = sys.argv[2]
+    token_file = sys.argv[3]
 
-	update_mirror(payload_or_payload_file)
+    update_mirror(event, payload_or_payload_file, token_file)

--- a/script/update-mirror.py
+++ b/script/update-mirror.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env  python
 
+"""Script to update content of a mirrored repository.
+
+This module is invoked from PHP whenever a GitHub event arrives from the 
+original repositories.
+
+"""
+
 import json
 import os
 import shutil

--- a/script/utils/githubmirrorutils.py
+++ b/script/utils/githubmirrorutils.py
@@ -3,135 +3,228 @@
 import os
 import re
 
+import json
+import urllib2
 from utils import normalise_repo_name
+
 from github import Github, GithubException
+import requests
+from requests.utils import quote
 
 
 class GithubMirrorUtils():
 
-	def __init__(self, tokenfile=None):
+    def __init__(self, tokenfile=None):
 
-		with open(tokenfile, "r") as f:
-			self.token = f.read().strip()
+        with open(tokenfile, "r") as f:
+            self.token = f.read().strip()
 
-			if self.token is None or self.token == "":
-				raise ValueError("File {} is empty".format(tokenfile))
+            if self.token is None or self.token == "":
+                raise ValueError("File {} is empty".format(tokenfile))
 
+    def print_user_login(self):
 
-	def print_user_login(self):
+        g = Github(self.token)
+        print g.get_user().login
 
-		g = Github(self.token)
+    def get_org_object(self, org_name):
 
-		print g.get_user().login
+        g = Github(self.token)
 
+        organization = None
+        for org in g.get_user().get_orgs():
+            if org_name == org.login:
+                organization = org
+                break
 
-	def create_update_mirror_repo(self, org_name, repo_name, src_url, pr_hook_url):
+        if organization is None:
+            print ("Token user is not inside the organization "
+                   "'{}'").format(org_name)
 
-		g = Github(self.token)
+        return organization
 
-		organisation = None
-		for org in g.get_user().get_orgs():
-			if org_name == org.login:
-				organisation = org
-				break
+    def get_public_org_object(self, org_name):
 
-		if organisation is None:
-			print "Token user is not inside the organisation '{}'".format(org_name)
-		else:
+        g = Github(self.token)
 
-			repo = None
-			try:
-				repo = org.get_repo(repo_name)
-				found = True
-			except GithubException:
-				found = False
+        organization = g.get_organization(org_name)
+        for org in g.get_user().get_orgs():
+            if org_name == org.login:
+                organization = org
+                break
 
-			if found:
-				print "WARNING: Repo '{}' already exists in the mirror github account".format(repo_name)
-			else:
-				repo = org.create_repo(repo_name)
-				print "Repo '{}' created".format(repo_name)
+        if organization is None:
+            print "Organization '{}' not found".format(org_name)
 
-			self.setup_basic_mirror_repo(repo, src_url, pr_hook_url)
-			print "Basc mirror setup completed"
+        return organization
 
-			
-	def setup_basic_mirror_repo(self, repo_object, src_url, pr_hook_url):
+    def get_repo_object(self, org_name, repo_name):
 
-		desc= "This is a mirror repo. Please fork from {}.".format(src_url)
+        organization = self.get_org_object(org_name)
 
-		repo_object.edit(repo_object.name, description=desc, has_issues=False)
+        repo = None
+        if organization is not None:
+            try:
+                repo = organization.get_repo(repo_name)
+            except GithubException:
+                print "Repo '{}' not found".format(repo_name)
 
+        return repo
 
-		name = "web"
-		config = {"url": pr_hook_url, "content_type": "json"}
-		events = ["pull_request"]
+    def get_public_repo_object(self, org_name, repo_name):
 
-		found = False
-		for hook in repo_object.get_hooks():
-			if hook.config["url"] == pr_hook_url:
-				found = True
+        organization = self.get_public_org_object(org_name)
 
-		if not found:
-			repo_object.create_hook(name=name, config=config, events=events)
+        repo = None
+        if organization is not None:
+            try:
+                repo = organization.get_repo(repo_name)
+            except GithubException:
+                print "Repo '{}' not found".format(repo_name)
 
+        return repo
 
-	def close_pull_request(self, org_name, repo_name, pull_request_number, src_url):
+    def create_update_mirror_repo(self, org_name, repo_name, src_url,
+                                  pr_hook_url):
 
-		reply = ("This is a mirror repo and the pull request has been closed automatically.\n"
-				"Please, submit your pull request to {}.").format(src_url)
+        repo = self.get_repo_object(org_name, repo_name)
 
-		g = Github(self.token)
+        if repo is not None:
+            print ("WARNING: Repo '{}' already exists in the mirror "
+                   "github account").format(repo_name)
+        else:
+            organization = self.get_org_object(org_name)
+            repo = organization.create_repo(repo_name)
+            print "Repo '{}' created".format(repo_name)
 
-		organisation = None
-		for org in g.get_user().get_orgs():
-			if org_name == org.login:
-				organisation = org
-				break
+        self.setup_basic_mirror_repo(repo, src_url, pr_hook_url)
+        print "Basic mirror setup completed"
 
-		if organisation is None:
-			print "Token user is not inside the organisation '{}'".format(org_name)
-		else:
+    def setup_basic_mirror_repo(self, repo_object, src_url, pr_hook_url):
 
-			repo = None
-			try:
-				repo = org.get_repo(repo_name)
-				found = True
-			except GithubException:
-				found = False
+        desc = "This is a mirror repo. Please fork from {}.".format(src_url)
 
-			if found:
-				pr = repo.get_pull(pull_request_number)
-	
-				if pr.state != "closed":
-					pr.create_issue_comment(reply)
-					pr.edit(state="closed")
-					print "Pull request with number {} has been closed".format(pull_request_number)
-				else:
-					print "Pull request with number {} is already closed".format(pull_request_number)
-			else:
-				print "Repo '{}' not found".format(repo_name)
+        repo_object.edit(repo_object.name, description=desc, has_issues=False)
 
+        name = "web"
+        config = {"url": pr_hook_url, "content_type": "json"}
+        events = ["pull_request"]
 
-	def print_org_repos_size(self, org_name):
+        found = False
+        for hook in repo_object.get_hooks():
+            if hook.config["url"] == pr_hook_url:
+                found = True
 
-		g = Github(self.token)
+        if not found:
+            repo_object.create_hook(name=name, config=config, events=events)
 
-		organisation = None
-		for org in g.get_user().get_orgs():
-			if org_name == org.login:
-				organisation = org
-				break
+    def close_pull_request(self, org_name, repo_name, pull_request_number,
+                           src_url):
 
-		if organisation is None:
-			print "Token user is not inside the organisation '{}'".format(org_name)
-		else:
-			repo_count = 0
-			total_size = 0
+        reply = ("This is a mirror repo and the pull request has been closed "
+                 "automatically.\n"
+                 "Please, submit your pull request to {}.").format(src_url)
 
-			for repo in organisation.get_repos():
-				repo_count += 1
-				total_size += repo.size
-				print "{}({} KB)".format(repo.name, repo.size)
+        repo = self.get_repo_object(org_name, repo_name)
 
-		print "Number of repos: \t{}\nTotal size (KB):\t{}".format(repo_count, total_size)
+        if repo is not None:
+            pr = repo.get_pull(pull_request_number)
+
+            if pr.state != "closed":
+                pr.create_issue_comment(reply)
+                pr.edit(state="closed")
+                print ("Pull request with number {} "
+                       "has been closed").format(pull_request_number)
+            else:
+                print ("Pull request with number {} is already "
+                       "closed").format(pull_request_number)
+
+    def print_org_repos_size(self, org_name):
+
+        organization = self.get_org_object(org_name)
+
+        if organization is not None:
+            repo_count = 0
+            total_size = 0
+
+            for repo in organization.get_repos():
+                repo_count += 1
+                total_size += repo.size
+                print "{}({} KB)".format(repo.name, repo.size)
+
+            print ("Number of repos: \t{}\n"
+                   "Total size (KB):\t{}").format(repo_count, total_size)
+
+    def create_release(self, org_name, repo_name, tag_name, name, body,
+                       draft, prerelease, assets):
+
+        repo = self.get_repo_object(org_name, repo_name)
+
+        if repo is None:
+            return
+
+        # Delete the release to recreate it
+        for release in repo.get_releases():
+            if release.tag_name == tag_name:
+                release.delete_release()
+
+        release = repo.create_git_release(tag=tag_name, name=name,
+                                          message=body, draft=draft,
+                                          prerelease=prerelease)
+
+        for asset in assets:
+            self.create_asset(asset["name"], asset["label"],
+                              asset["content_type"],
+                              asset["browser_download_url"],
+                              release.upload_url)
+
+    def create_asset(self, name, label, content_type, download_url,
+                     upload_url):
+
+        if label is None:
+            upload_url = upload_url.replace("{?name,label}", "") + "?name={}"
+            upload_url = upload_url.format(name)
+        else:
+            upload_url = upload_url.replace("{?name,label}", "") +\
+                "?name={}&label={}"
+            upload_url = upload_url.format(name, quote(label))
+
+        headers = {"Content-type": content_type,
+                   "Authorization": "token {}".format(self.token)}
+
+        data = urllib2.urlopen(download_url).read()
+
+        res = requests.post(url=upload_url,
+                            data=data,
+                            headers=headers,
+                            verify=False)
+
+    def recreate_releases(self, source_org, source_repo, mirror_org,
+                          mirror_repo):
+
+        print "Recreating releases for repository {}/{}".format(mirror_org,
+                                                                mirror_repo)
+
+        page = 1
+        headers = {"Authorization": "token {}".format(self.token)}
+        next_page = True
+
+        while next_page:
+            url = ("https://api.github.com/repos"
+                   "/{}/{}/releases?page={}").format(source_org, source_repo,
+                                                     page)
+            res = requests.get(url=url,
+                               headers=headers,
+                               verify=False)
+
+            releases = json.loads(res.text)
+            for release in releases:
+                self.create_release(mirror_org, mirror_repo,
+                                    release["tag_name"], release["name"],
+                                    release["body"], release["draft"],
+                                    release["prerelease"], release["assets"])
+
+            page += 1
+            if not ("link" in res.headers and
+                    'rel="next"' in res.headers["link"]):
+                next_page = False

--- a/script/utils/utils.py
+++ b/script/utils/utils.py
@@ -1,11 +1,20 @@
 #! /usr/bin/env  python
 
+"""Module for general utility functions.
+
+The functions implemented in this module serve as utility functions for 
+string management, folder management and FIWARE naming conventions enforcing.
+
+"""
+
 import os
 import re
 
 
 class cd:
-    """Context manager for changing the current working directory"""
+
+    """Context manager for changing the current working directory."""
+
     def __init__(self, newPath):
         self.newPath = os.path.expanduser(newPath)
 
@@ -18,6 +27,7 @@ class cd:
 
 
 def get_user_repo_from_github_url(url):
+    """Extract from GitHub URL the owner and repository names."""
 
     regex = ('(?:https://github.com/(?P<user1>.*)/(?P<repo1>.*).git)|'
              '(?:git://github.com/(?P<user2>.*)/(?P<repo2>.*).git)|'
@@ -45,6 +55,7 @@ def get_user_repo_from_github_url(url):
 
 
 def filter_fiware_prefix(name):
+    """Strip FIWARE prefixes from the input name."""
 
     regex = r'(?i)(fiware-?|fi-ware-?)'
     fiware_prefix_pattern = re.compile(regex)
@@ -55,6 +66,7 @@ def filter_fiware_prefix(name):
 
 
 def capitalise_after_chapter(name):
+    """Capitalise the repository name after the chapter name."""
 
     pos = name.find('.')
 
@@ -66,11 +78,13 @@ def capitalise_after_chapter(name):
 
 
 def normalise_repo_name(repo_name):
+    """Apply FIWARE naming conventions to the repository name."""
 
     return capitalise_after_chapter(filter_fiware_prefix(repo_name))
 
 
 def parse_clone_mirror_list_chapter(urls, chapter, github_org):
+    """Transform a list of repositry URLs into webhook conf format."""
 
     clone_mirror_list = []
     for url in urls:

--- a/script/utils/utils.py
+++ b/script/utils/utils.py
@@ -19,75 +19,76 @@ class cd:
 
 def get_user_repo_from_github_url(url):
 
-	regex = ('(?:https://github.com/(?P<user1>.*)/(?P<repo1>.*).git)|'
-		 '(?:git://github.com/(?P<user2>.*)/(?P<repo2>.*).git)|'
-		 '(?:git@github.com:(?P<user3>.*)/(?P<repo3>.*).git)')
+    regex = ('(?:https://github.com/(?P<user1>.*)/(?P<repo1>.*).git)|'
+             '(?:git://github.com/(?P<user2>.*)/(?P<repo2>.*).git)|'
+             '(?:git@github.com:(?P<user3>.*)/(?P<repo3>.*).git)')
 
-	github_pattern = re.compile(regex)
+    github_pattern = re.compile(regex)
 
-	url = url.strip(' \t\n\r')
+    url = url.strip(' \t\n\r')
 
-	match_result = github_pattern.match(url)
+    match_result = github_pattern.match(url)
 
-	if match_result:
-		result = match_result.groupdict()
+    if match_result:
+        result = match_result.groupdict()
 
-		user = result['user1'] or  result['user2'] or result['user3']
-		repo = result['repo1'] or  result['repo2'] or result['repo3']
+        user = result['user1'] or result['user2'] or result['user3']
+        repo = result['repo1'] or result['repo2'] or result['repo3']
 
-		if user and repo:
-			return {'user':user, 'repo':repo}
-		else:
-			raise ValueError("Error found with URL parsing")
-	else:
-		raise ValueError('The URL {} has invalid Github URL format.'.format(url))
+        if user and repo:
+            return {'user': user, 'repo': repo}
+        else:
+            raise ValueError("Error found with URL parsing")
+    else:
+        raise ValueError(('The URL {} has invalid Github '
+                          'URL format.').format(url))
 
 
 def filter_fiware_prefix(name):
 
-	regex = r'(?i)(fiware-?|fi-ware-?)'
-	fiware_prefix_pattern = re.compile(regex)
+    regex = r'(?i)(fiware-?|fi-ware-?)'
+    fiware_prefix_pattern = re.compile(regex)
 
-	filtered_name = re.sub(fiware_prefix_pattern, '', name)
+    filtered_name = re.sub(fiware_prefix_pattern, '', name)
 
-	return filtered_name
+    return filtered_name
 
 
 def capitalise_after_chapter(name):
 
-	pos = name.find('.')
+    pos = name.find('.')
 
-	name_list = list(name)
+    name_list = list(name)
 
-	name_list[pos+1] = name_list[pos+1].upper()
+    name_list[pos+1] = name_list[pos+1].upper()
 
-	return "".join(name_list)
+    return "".join(name_list)
 
 
 def normalise_repo_name(repo_name):
 
-	return capitalise_after_chapter(filter_fiware_prefix(repo_name))
+    return capitalise_after_chapter(filter_fiware_prefix(repo_name))
 
 
 def parse_clone_mirror_list_chapter(urls, chapter, github_org):
 
-	clone_mirror_list = []
-	for url in urls:
-		if url.endswith('/'):
-			url = url[0:-1]
+    clone_mirror_list = []
+    for url in urls:
+        if url.endswith('/'):
+            url = url[0:-1]
 
-		if len(url.split('/')) < 5:
-			print "No repo in {}".format(url)
-			continue
+        if len(url.split('/')) < 5:
+            print "No repo in {}".format(url)
+            continue
 
-		repo_name = url.split('/')[4]
-		source_url = url + '.git'
-		if chapter == 'data':
-			chapter == 'context'
-		repo_name = normalise_repo_name(chapter+'.'+repo_name)
-		remote_url = 'git@github.com:{}/{}.git'.format(github_org, 
-					  repo_name)
+        repo_name = url.split('/')[4]
+        source_url = url + '.git'
+        if chapter == 'data':
+            chapter == 'context'
+        repo_name = normalise_repo_name(chapter+'.'+repo_name)
+        remote_url = 'git@github.com:{}/{}.git'.format(github_org,
+                                                       repo_name)
 
-		clone_mirror_list.append([source_url, remote_url]) 
+        clone_mirror_list.append([source_url, remote_url])
 
-	return clone_mirror_list
+    return clone_mirror_list

--- a/web/index.php
+++ b/web/index.php
@@ -3,37 +3,58 @@ require 'Slim-2.6.2/Slim/Slim.php';
 \Slim\Slim::registerAutoloader();
 
 $app = new \Slim\Slim();
- 
+
 $app->contentType('application/json; charset=utf-8');
- 
+
 $app->get('/', function() {
             echo "Welcome to mirror-webhook.";
         });
   
 $app->post('/hook',function() use($app){
-            $body = $app->request->getBody();
 
-            $update_script = "/home/fiwareulpgc/mirrors/script/update-mirror.py";
+    $update_script = "/home/fiwareulpgc/mirrors/script/update-mirror.py";
+    $github_token_file = "/home/fiwareulpgc/mirrors/script/utils/github-token";
+    $event = $app->request->headers->get('X-GitHub-Event');
+    $body = $app->request->getBody();
 
-            $output = shell_exec("sudo -u fiwareulpgc ".$update_script." '".$body."'");
+    $command = "sudo -u fiwareulpgc ".$update_script." '".$event."'";
+    $command .= " '".$body."' ".$github_token_file." 2>&1";
 
-            echo $body;
+    exec($command, $output, $return_var);
 
-            $app->response->setStatus(200);
+    if ($return_var == 0){
+        echo "OK";
+        $app->response->setStatus(200);
+    }
+    else{
+        error_log(implode("\n", $output));
+        echo "Internal server error";
+        $app->response->setStatus(500);
+    }
+
 });
 
 $app->post('/deny-pull-request',function() use($app){
-            $body = $app->request->getBody();
 
-            $deny_script = "/home/fiwareulpgc/mirrors/script/deny-pull-requests.py";
-            $github_token_file = "/home/fiwareulpgc/mirrors/script/utils/token-fiware.txt";
+    $deny_script = "/home/fiwareulpgc/mirrors/script/deny-pull-requests.py";
+    $github_token_file = "/home/fiwareulpgc/mirrors/script/utils/github-token";
+    $body = $app->request->getBody();
 
-            $output = shell_exec("sudo -u fiwareulpgc ".$deny_script." '".$body."' ".$github_token_file);
+    $command = "sudo -u fiwareulpgc ".$deny_script;
+    $command .= " '".$body."' ".$github_token_file." 2>&1";
 
-            echo $body;
+    exec($command, $output, $return_var);
 
-            $app->response->setStatus(200);
+    if ($return_var == 0){
+        echo "OK";
+        $app->response->setStatus(200);
+    }
+    else{
+        error_log(implode("\n", $output));
+        echo "Internal server error";
+        $app->response->setStatus(500);
+    }
 });
- 
+
 $app->run();
 ?>


### PR DESCRIPTION
This PR implements the support for the functionality asked in #3:
- Now the webhook service is able to identify [**Release** events](https://developer.github.com/v3/activity/events/types/#releaseevent) and recreate a newly published release inside the mirror repository. 
- The setup function has been also updated to recreate all releases when a new mirror is created.
- A new backend utility has been added to recreate all the releases for the already existing mirror repositories.
- The documentation has been updated to reflect the changes in requirements and functionality.
